### PR TITLE
Fix cross-platform todo file path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,15 @@ mod todo_list;
 use args::{AddCommand, Cli, MarkCommand};
 use clap::Parser;
 use std::fs;
+use std::path::PathBuf;
 use todo_list::TodoList;
 
-const PATH: &str = "c:/tmp/todo.txt";
+
+fn todo_path() -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push("todo.txt");
+    path
+}
 
 fn main() {
     // Get args
@@ -15,7 +21,8 @@ fn main() {
     let mut list: TodoList;
 
     // Read list from fs
-    match fs::read_to_string(PATH) {
+    let path = todo_path();
+    match fs::read_to_string(&path) {
         Ok(data) => {
             list = serde_json::from_str(&data[..]).unwrap();
         }
@@ -40,5 +47,5 @@ fn main() {
 
     // Write list to fs
     let serialized = serde_json::to_string(&list).unwrap();
-    fs::write(PATH, serialized).expect("Unable to write file");
+    fs::write(path, serialized).expect("Unable to write file");
 }


### PR DESCRIPTION
## Summary
- store the todo file in the OS temp directory
- remove hard-coded Windows path

## Testing
- `cargo check`
- `cargo run -- list`
- `cargo run -- add "Buy milk"`
- `cargo run -- list`


------
https://chatgpt.com/codex/tasks/task_b_685bb6727610832e84f05587cac0bae7