### PR TITLE
Fix tests for TodoList

### DIFF
--- a/src/todo_list.rs
+++ b/src/todo_list.rs
@@ -19,18 +19,12 @@ impl TodoList {
             Self::Container { items, .. } => {
                 items.push(item);
             }
-            Self::Item { mark, text } => {
-                let original_mark = *mark;
+            Self::Item { text, .. } => {
                 let original_text = text.clone();
 
-                *self = Self::new(text.clone());
+                *self = Self::new(original_text);
 
                 if let Self::Container { items, .. } = self {
-                    items.push(Self::Item {
-                        mark: original_mark,
-                        text: original_text,
-                    });
-
                     items.push(item);
                 }
             }


### PR DESCRIPTION
## Summary
- fix `add_item` to not duplicate the original item when turning an `Item` into a `Container`
- all tests now pass

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_b_685bbacb9468832e95043d2013c1f551